### PR TITLE
Reporter mpi

### DIFF
--- a/examples/eight_heat_sources/adjoint.i
+++ b/examples/eight_heat_sources/adjoint.i
@@ -79,7 +79,7 @@
 
 [VectorPostprocessors]
   [point_source]
-    type = ConstantVectorPostprocessor
+    type = ParConstantVectorPostprocessor
     vector_names = 'x y z value'
     value = '0.5 0.5 0.5 0.5 0.5 0.5 0.5 0.5 0.5
              0.9 0.9 0.9 0.9 0.9 0.9 0.9 0.9 0.9

--- a/examples/eight_heat_sources/forward.i
+++ b/examples/eight_heat_sources/forward.i
@@ -84,7 +84,7 @@
 
 [VectorPostprocessors]
   [point_source]
-    type = ConstantVectorPostprocessor
+    type = ParConstantVectorPostprocessor
     vector_names = 'x y z value'
     value = '0.3 0.3 0.3 0.3 0.7 0.7 0.7 0.7;
              0.8 0.6 0.4 0.2 0.8 0.6 0.4 0.2;

--- a/include/vectorpostprocessors/ParConstantVectorPostprocessor.h
+++ b/include/vectorpostprocessors/ParConstantVectorPostprocessor.h
@@ -1,0 +1,26 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "GeneralVectorPostprocessor.h"
+
+class ParConstantVectorPostprocessor : public GeneralVectorPostprocessor
+{
+public:
+  static InputParameters validParams();
+
+  ParConstantVectorPostprocessor(const InputParameters & parameters);
+
+  virtual void initialize() override;
+  virtual void execute() override;
+
+protected:
+  std::vector<VectorPostprocessorValue *> _value;
+};

--- a/src/formfunctions/ObjectiveMinimize.C
+++ b/src/formfunctions/ObjectiveMinimize.C
@@ -20,7 +20,7 @@ ObjectiveMinimize::computeAndCheckObjective(bool multiapp_passed)
 
   if (multiapp_passed)
   {
-    for (auto i = 0; i < _parameters.size(); ++i)
+    for (unsigned int i = 0; i < _parameters.size(); ++i)
     {
       for (auto & val : *_parameters[i])
       {

--- a/src/vectorpostprocessors/ParConstantVectorPostprocessor.C
+++ b/src/vectorpostprocessors/ParConstantVectorPostprocessor.C
@@ -1,0 +1,68 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "ParConstantVectorPostprocessor.h"
+
+registerMooseObject("MooseApp", ParConstantVectorPostprocessor);
+
+defineLegacyParams(ParConstantVectorPostprocessor);
+
+InputParameters
+ParConstantVectorPostprocessor::validParams()
+{
+  InputParameters params = GeneralVectorPostprocessor::validParams();
+  params.addClassDescription(
+      "Populate constant VectorPostprocessorValue directly from input file.");
+  params.addParam<std::vector<std::string>>("vector_names",
+                                            "Names of the column vectors in this object");
+  params.addRequiredParam<std::vector<std::vector<Real>>>(
+      "value",
+      "Vector values this object will have. Leading dimension must be equal to leading dimension "
+      "of vector_names parameter.");
+  return params;
+}
+
+ParConstantVectorPostprocessor::ParConstantVectorPostprocessor(const InputParameters & parameters)
+  : GeneralVectorPostprocessor(parameters)
+{
+
+  std::vector<std::string> names;
+  if (isParamValid("vector_names"))
+    names = getParam<std::vector<std::string>>("vector_names");
+  else
+    names = {"value"};
+  unsigned int nvec = names.size();
+
+  _value.resize(nvec);
+  for (unsigned int j = 0; j < nvec; ++j)
+    _value[j] = &declareVector(names[j]);
+
+  std::vector<std::vector<Real>> v = getParam<std::vector<std::vector<Real>>>("value");
+  if (v.size() != nvec)
+    paramError("value",
+               "Leading dimension must be equal to leading dimension of vector_names parameter.");
+
+  for (unsigned int j = 0; j < nvec; ++j)
+  {
+    unsigned int ne = v[j].size();
+    _value[j]->resize(ne);
+    for (unsigned int l = 0; l < ne; ++l)
+      (*_value[j])[l] = v[j][l];
+  }
+}
+
+void
+ParConstantVectorPostprocessor::initialize()
+{
+}
+
+void
+ParConstantVectorPostprocessor::execute()
+{
+}

--- a/test/tests/formfunction/objective_gradient_minimize/bc_load_linearFunction/adjoint.i
+++ b/test/tests/formfunction/objective_gradient_minimize/bc_load_linearFunction/adjoint.i
@@ -98,7 +98,7 @@
 
 [VectorPostprocessors]
   [point_source]
-    type = ConstantVectorPostprocessor
+    type = ParConstantVectorPostprocessor
     vector_names = 'x y z value'
     value = '0.2 0.8 0.2 0.8;
              0.2 0.6 1.4 1.8;

--- a/test/tests/formfunction/objective_gradient_minimize/bc_load_linearFunction/tests
+++ b/test/tests/formfunction/objective_gradient_minimize/bc_load_linearFunction/tests
@@ -9,4 +9,13 @@
     input = master.i
     csvdiff = master_out_receiver_0001.csv
   []
+  [taolmvm_par]
+    requirement = "Make sure everything is working in parallel, like the constantvectorpostprocessor"
+                  " and the vectorpostprocessor dirac kernel" 
+    type = CSVDiff
+    rel_err = 0.01
+    input = master.i
+    min_parallel = 2
+    csvdiff = master_out_receiver_0001.csv
+  []
 []


### PR DESCRIPTION
I added a new ConstantVectorPostprocessor that works in Paralell for our problem.  I couldn't get the ConstantVectorPostprocessor in Moose to replicate the data across processors.  I also added a paralell test.  This wasn't a problem until the reporter was added because we were not using the constantVectorPostprocessor to transfer controllable data before the reporter.   But this issue has nothing to do with the reporter or transfers or multiapps, it can be reproduced by running the forward problem by itself.  I'll try to make a test on Monday that I can post on the moose discussions board
